### PR TITLE
Bump tiiuae/fog-ros-baseimage from sha-2f516bb to v2.0.0

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -5,7 +5,7 @@
         "dockerfile": "Dockerfile.dev",
         "args": {
             "ARCH": "amd64",
-            "ROS_VERSION": "galactic",
+            "ROS_VERSION": "humble",
             "USER_ID": "1000",
             "GROUP_ID": "1000"
         }

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ghcr.io/tiiuae/fog-ros-baseimage:builder-2f516bb AS builder
+FROM ghcr.io/tiiuae/fog-ros-baseimage-builder:dp-4266_humble_upgrade AS builder
 
 # Install build dependencies
 RUN apt-get update -y && apt-get install -y --no-install-recommends \
@@ -21,7 +21,7 @@ RUN /packaging/build.sh
 #  ▲               runtime ──┐
 #  └── build                 ▼
 
-FROM ghcr.io/tiiuae/fog-ros-baseimage:sha-2f516bb
+FROM ghcr.io/tiiuae/fog-ros-baseimage:dp-4266_humble_upgrade
 
 RUN apt-get update -y && apt-get install -y --no-install-recommends \
     ros-${ROS_DISTRO}-mavros-msgs \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ghcr.io/tiiuae/fog-ros-baseimage-builder:dp-4266_humble_upgrade AS builder
+FROM ghcr.io/tiiuae/fog-ros-baseimage-builder:v2.0.0 AS builder
 
 # Install build dependencies
 RUN apt-get update -y && apt-get install -y --no-install-recommends \
@@ -21,7 +21,7 @@ RUN /packaging/build.sh
 #  ▲               runtime ──┐
 #  └── build                 ▼
 
-FROM ghcr.io/tiiuae/fog-ros-baseimage:dp-4266_humble_upgrade
+FROM ghcr.io/tiiuae/fog-ros-baseimage:v2.0.0
 
 RUN apt-get update -y && apt-get install -y --no-install-recommends \
     ros-${ROS_DISTRO}-mavros-msgs \

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,9 +1,9 @@
 #!/bin/bash -e
 
-source /opt/ros/galactic/setup.bash
+source /opt/ros/humble/setup.bash
 
 # The mesh-com project had issues resolving packages without this.
-export PYTHONPATH=/opt/ros/galactic/lib/python3.8/site-packages
+export PYTHONPATH=/opt/ros/humble/lib/python3.8/site-packages
 
 echo "Starting the RTK GPS client (ntrip_client)"
 


### PR DESCRIPTION
Update fog-ros-baseimage from sha-2f516bb to v2.0.0

**This PR is now ready to merge.**
