### PR TITLE
Baseimage upgrade to support multi-arch builds

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -2,22 +2,21 @@ name: tii-ntrip-client
 
 on:
   push:
-    branches: [ main, develop, master ]
-    tags:
-      - 'v*'
-      - v[0-9]+.[0-9]+.[0-9]+
-      - v[0-9]+.[0-9]+.[0-9]+-rc.[0-9]+
   pull_request:
     branches: [master]
 
 jobs:
-  tii-ntrip-client:
+  main:
+    name: 🔨
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@v3
 
-      - uses: actions/checkout@v2
+      - uses: docker/setup-qemu-action@v2
+        with:
+          platforms: riscv64,arm64
 
-      - uses: docker/setup-buildx-action@v1
+      - uses: docker/setup-buildx-action@v2
 
       - name: Docker meta
         id: meta
@@ -41,7 +40,7 @@ jobs:
         uses: docker/build-push-action@v2
         with:
           context: .
-          file: ./Dockerfile
+          platforms: linux/amd64,linux/riscv64,linux/arm64
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -5,6 +5,10 @@ on:
   pull_request:
     branches: [master]
 
+permissions:
+  contents: read
+  packages: write
+
 jobs:
   main:
     name: 🔨

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -15,17 +15,17 @@ jobs:
     name: 🔨
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - uses: docker/setup-qemu-action@v2
         with:
           platforms: amd64,riscv64,arm64
 
-      - uses: docker/setup-buildx-action@v2
+      - uses: docker/setup-buildx-action@v3
 
       - name: Docker meta
         id: meta
-        uses: docker/metadata-action@v3
+        uses: docker/metadata-action@v5
         with:
           images: ghcr.io/tiiuae/tii-ntrip-client
           tags: |
@@ -35,14 +35,14 @@ jobs:
             type=raw,value=latest
 
       - name: Login to GitHub Container Registry
-        uses: docker/login-action@v1
+        uses: docker/login-action@v3
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build tii-ntrip-client image and push
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@v5
         with:
           context: .
           platforms: linux/amd64,linux/riscv64,linux/arm64

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -4,6 +4,7 @@ on:
   push:
   pull_request:
     branches: [master]
+  workflow_dispatch:
 
 permissions:
   contents: read

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -18,7 +18,7 @@ jobs:
 
       - uses: docker/setup-qemu-action@v2
         with:
-          platforms: riscv64,arm64
+          platforms: amd64,riscv64,arm64
 
       - uses: docker/setup-buildx-action@v2
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Given dynamically from CI job.
-FROM --platform=${BUILDPLATFORM:-linux/amd64} ghcr.io/tiiuae/fog-ros-sdk:sha-6d67ecf-${TARGETARCH:-amd64} AS builder
+FROM --platform=${BUILDPLATFORM:-linux/amd64} ghcr.io/tiiuae/fog-ros-sdk:v3.0.0-${TARGETARCH:-amd64} AS builder
 
 # Must be defined another time after "FROM" keyword.
 ARG TARGETARCH
@@ -11,7 +11,7 @@ RUN /packaging/build_colcon_sdk.sh ${TARGETARCH:-amd64}
 #  ▲               runtime ──┐
 #  └── build                 ▼
 
-FROM ghcr.io/tiiuae/fog-ros-baseimage:sha-6d67ecf
+FROM ghcr.io/tiiuae/fog-ros-baseimage:v3.0.0
 
 RUN apt-get update \
     && apt-get install -y \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,12 @@
-FROM ghcr.io/tiiuae/fog-ros-baseimage:feat-multiarch-pkcs11 AS builder
+# Given dynamically from CI job.
+FROM --platform=${BUILDPLATFORM:-linux/amd64} ghcr.io/tiiuae/fog-ros-sdk:sha-f8defd3-${TARGETARCH:-amd64} AS builder
+
+# Must be defined another time after "FROM" keyword.
+ARG TARGETARCH
 
 COPY . $SRC_DIR/ntrip_client
 
-RUN /packaging/build_colcon.sh
+RUN /packaging/build_colcon_sdk.sh ${TARGETARCH:-amd64}
 
 #  ▲               runtime ──┐
 #  └── build                 ▼

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,17 +1,13 @@
-# Given dynamically from CI job.
-FROM --platform=${BUILDPLATFORM:-linux/amd64} ghcr.io/tiiuae/fog-ros-sdk:sha-f8defd3-${TARGETARCH:-amd64} AS builder
-
-# Must be defined another time after "FROM" keyword.
-ARG TARGETARCH
+FROM ghcr.io/tiiuae/fog-ros-baseimage-builder:sha-6d67ecf AS builder
 
 COPY . $SRC_DIR/ntrip_client
 
-RUN /packaging/build_colcon_sdk.sh ${TARGETARCH:-amd64}
+RUN /packaging/build_colcon.sh
 
 #  ▲               runtime ──┐
 #  └── build                 ▼
 
-FROM ghcr.io/tiiuae/fog-ros-baseimage:feat-multiarch-pkcs11
+FROM ghcr.io/tiiuae/fog-ros-baseimage:sha-6d67ecf
 
 RUN apt-get update \
     && apt-get install -y \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ghcr.io/tiiuae/fog-ros-baseimage-builder:sha-f8defd3 AS builder
+FROM ghcr.io/tiiuae/fog-ros-baseimage:feat-multiarch-pkcs11 AS builder
 
 COPY . $SRC_DIR/ntrip_client
 
@@ -7,7 +7,7 @@ RUN /packaging/build_colcon.sh
 #  ▲               runtime ──┐
 #  └── build                 ▼
 
-FROM ghcr.io/tiiuae/fog-ros-baseimage:sha-f8defd3
+FROM ghcr.io/tiiuae/fog-ros-baseimage:feat-multiarch-pkcs11
 
 RUN apt-get update \
     && apt-get install -y \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,12 @@
-FROM ghcr.io/tiiuae/fog-ros-baseimage-builder:sha-6d67ecf AS builder
+# Given dynamically from CI job.
+FROM --platform=${BUILDPLATFORM:-linux/amd64} ghcr.io/tiiuae/fog-ros-sdk:sha-6d67ecf-${TARGETARCH:-amd64} AS builder
+
+# Must be defined another time after "FROM" keyword.
+ARG TARGETARCH
 
 COPY . $SRC_DIR/ntrip_client
 
-RUN /packaging/build_colcon.sh
+RUN /packaging/build_colcon_sdk.sh ${TARGETARCH:-amd64}
 
 #  ▲               runtime ──┐
 #  └── build                 ▼

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Given dynamically from CI job.
-FROM --platform=${BUILDPLATFORM:-linux/amd64} ghcr.io/tiiuae/fog-ros-sdk:v3.0.0-${TARGETARCH:-amd64} AS builder
+FROM --platform=${BUILDPLATFORM:-linux/amd64} ghcr.io/tiiuae/fog-ros-sdk:v3.0.1-${TARGETARCH:-amd64} AS builder
 
 # Must be defined another time after "FROM" keyword.
 ARG TARGETARCH
@@ -11,7 +11,7 @@ RUN /packaging/build_colcon_sdk.sh ${TARGETARCH:-amd64}
 #  ▲               runtime ──┐
 #  └── build                 ▼
 
-FROM ghcr.io/tiiuae/fog-ros-baseimage:v3.0.0
+FROM ghcr.io/tiiuae/fog-ros-baseimage:v3.0.1
 
 RUN apt-get update \
     && apt-get install -y \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ghcr.io/tiiuae/fog-ros-baseimage-builder:sha-549d28a AS builder
+FROM ghcr.io/tiiuae/fog-ros-baseimage-builder:sha-f8defd3 AS builder
 
 COPY . $SRC_DIR/ntrip_client
 
@@ -7,7 +7,7 @@ RUN /packaging/build_colcon.sh
 #  ▲               runtime ──┐
 #  └── build                 ▼
 
-FROM ghcr.io/tiiuae/fog-ros-baseimage:sha-549d28a
+FROM ghcr.io/tiiuae/fog-ros-baseimage:sha-f8defd3
 
 RUN apt-get update \
     && apt-get install -y \

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,9 +1,0 @@
-#!/bin/bash -e
-
-source /opt/ros/humble/setup.bash
-
-echo "Starting the RTK GPS client (ntrip_client)"
-
-mkdir -p ~/.ros/log
-
-ros2 launch ntrip_client ntrip_client_launch.py

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,4 +1,5 @@
-
+[build_scripts]
+executable=/usr/bin/env python3
 [develop]
 script_dir=$base/lib/ntrip_client
 [install]


### PR DESCRIPTION
This PR brings the functionality to build component in amd64, arm64, and riscv64 architectures.

For further information about the baseimage related changes, see [fog-ros-baseimage/docs
/Multiarchitecture_builds.md](https://github.com/tiiuae/fog-ros-baseimage/blob/main/docs/Multiarchitecture_builds.md)

Merge of this PR will be done by the fog-ros-baseimage maintainers.
