### PR TITLE
PKCS11 updates

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Given dynamically from CI job.
-FROM --platform=${BUILDPLATFORM:-linux/amd64} ghcr.io/tiiuae/fog-ros-sdk:v3.1.0-${TARGETARCH:-amd64} AS builder
+FROM --platform=${BUILDPLATFORM:-linux/amd64} ghcr.io/tiiuae/fog-ros-sdk:v3.2.0-${TARGETARCH:-amd64} AS builder
 
 # Must be defined another time after "FROM" keyword.
 ARG TARGETARCH
@@ -11,7 +11,7 @@ RUN /packaging/build_colcon_sdk.sh ${TARGETARCH:-amd64}
 #  ▲               runtime ──┐
 #  └── build                 ▼
 
-FROM ghcr.io/tiiuae/fog-ros-baseimage:v3.1.0
+FROM ghcr.io/tiiuae/fog-ros-baseimage:v3.2.0
 
 RUN apt-get update \
     && apt-get install -y \


### PR DESCRIPTION
- upgrade base images v3.1.0 to v3.2.0
- remove obsolete PKCS11 related env vars
- upgrade msgs-nats if applicable
