### PR TITLE
Ntrip msg type print and disable dropping len>255

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,6 +18,7 @@ RUN apt-get update \
         nmea-msgs \
     && rm -rf /var/lib/apt/lists/*
 
-ENTRYPOINT ros-with-env ros2 launch ntrip_client ntrip_client_launch.py
+COPY entrypoint.sh /entrypoint.sh
+ENTRYPOINT [ "/entrypoint.sh" ]
 
 COPY --from=builder $INSTALL_DIR $INSTALL_DIR

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,0 +1,42 @@
+#!/bin/bash -e
+
+_term() {
+    # FILL UP PROCESS SEARCH PATTERN HERE TO FIND PROPER PROCESS FOR SIGINT:
+    pattern="ntrip_client/ntrip_ros.py"
+
+    pid_value="$(ps -e | grep $pattern | grep -v grep | awk '{ print $1 }')"
+    if [ "$pid_value" != "" ]; then
+        pid=$pid_value
+        echo "Send SIGINT to pid $pid"
+    else
+        pid=1
+        echo "Pattern not found, send SIGINT to pid $pid"
+    fi
+    kill -s SIGINT $pid
+}
+# Use SIGTERM or TERM, does not seem to make any difference.
+trap _term TERM
+
+ros-with-env ros2 launch ntrip_client ntrip_client_launch.py &
+child=$!
+
+echo "Waiting for pid $child"
+# * Calling "wait" will then wait for the job with the specified by $child to finish, or for any signals to be fired.
+#   Due to "or for any signals to be fired", "wait" will also handle SIGTERM and it will shutdown before
+#   the node ends gracefully.
+#   The solution is to add a second "wait" call and remove the trap between the two calls.
+# * Do not use -e flag in the first wait call because wait will exit with error after catching SIGTERM.
+set +e
+wait $child
+set -e
+trap - TERM
+wait $child
+RESULT=$?
+
+if [ $RESULT -ne 0 ]; then
+    echo "ERROR: ntrip node failed with code $RESULT" >&2
+    exit $RESULT
+else
+    echo "INFO: ntrip node finished successfully, but returning 125 code for docker to restart properly." >&2
+    exit 125
+fi

--- a/scripts/ntrip_ros.py
+++ b/scripts/ntrip_ros.py
@@ -103,6 +103,7 @@ class NTRIPRos(Node):
     self._rtcm_pub = self.create_publisher(self._rtcm_message_type, '/fmu/in/GpsInjectData', 1000)
     # self._rtcm_pub = self.create_publisher(self._rtcm_message_type, 'rtcm', 1000)
 
+    self.get_logger().warning('Workaround print so we get a connection to RTK server.')
 
     # Initialize the client
     self._client = NTRIPClient(


### PR DESCRIPTION
## Changelog:
- The message types and sizes are not added to the logs, which could be helpful in future to debug ntrip issues.
- Disabled dropping len>255 messages. This was introduced due to a limitation of the px4-msgs, which has uint8 to define the length. This was fixed after the 1.14 upgrades. So, it is not needed anymore.