### PR TITLE
Use pkcs11-closer to remove sessions references

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,6 +11,8 @@ RUN /packaging/build_colcon_sdk.sh ${TARGETARCH:-amd64}
 #  ▲               runtime ──┐
 #  └── build                 ▼
 
+FROM ghcr.io/tiiuae/pkcs11-closer:sha-7bec028 AS closer
+
 FROM ghcr.io/tiiuae/fog-ros-baseimage:v3.2.0
 
 RUN apt-get update \
@@ -21,4 +23,5 @@ RUN apt-get update \
 COPY entrypoint.sh /entrypoint.sh
 ENTRYPOINT [ "/entrypoint.sh" ]
 
+COPY --from=closer /pkcs11-closer /
 COPY --from=builder $INSTALL_DIR $INSTALL_DIR

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -33,6 +33,8 @@ trap - TERM
 wait $child
 RESULT=$?
 
+/pkcs11-closer --label ntrip-client
+
 if [ $RESULT -ne 0 ]; then
     echo "ERROR: ntrip node failed with code $RESULT" >&2
     exit $RESULT


### PR DESCRIPTION
Pkcs11-closer is an utility application which closes PKCS#11 sessions which may have been left behind and open due to some erratic behaviour. This should fix similar issue as reported in [DP-9022](https://ssrc.atlassian.net/browse/DP-9022).