### PR TITLE
Bump tiiuae/fog-ros-baseimage from v3.3.0 to v3.4.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Given dynamically from CI job.
-FROM --platform=${BUILDPLATFORM:-linux/amd64} ghcr.io/tiiuae/fog-ros-sdk:sha-c04d413-${TARGETARCH:-amd64} AS builder
+FROM --platform=${BUILDPLATFORM:-linux/amd64} ghcr.io/tiiuae/fog-ros-sdk:v3.4.0-${TARGETARCH:-amd64} AS builder
 
 # Must be defined another time after "FROM" keyword.
 ARG TARGETARCH
@@ -13,7 +13,7 @@ RUN /packaging/build_colcon_sdk.sh ${TARGETARCH:-amd64}
 
 FROM ghcr.io/tiiuae/pkcs11-closer:sha-7bec028 AS closer
 
-FROM ghcr.io/tiiuae/fog-ros-baseimage:sha-c04d413
+FROM ghcr.io/tiiuae/fog-ros-baseimage:v3.4.0
 
 RUN apt-get update \
     && apt-get install -y \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Given dynamically from CI job.
-FROM --platform=${BUILDPLATFORM:-linux/amd64} ghcr.io/tiiuae/fog-ros-sdk:sha-926c935-${TARGETARCH:-amd64} AS builder
+FROM --platform=${BUILDPLATFORM:-linux/amd64} ghcr.io/tiiuae/fog-ros-sdk:sha-c04d413-${TARGETARCH:-amd64} AS builder
 
 # Must be defined another time after "FROM" keyword.
 ARG TARGETARCH
@@ -13,7 +13,7 @@ RUN /packaging/build_colcon_sdk.sh ${TARGETARCH:-amd64}
 
 FROM ghcr.io/tiiuae/pkcs11-closer:sha-7bec028 AS closer
 
-FROM ghcr.io/tiiuae/fog-ros-baseimage:sha-926c935
+FROM ghcr.io/tiiuae/fog-ros-baseimage:sha-c04d413
 
 RUN apt-get update \
     && apt-get install -y \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Given dynamically from CI job.
-FROM --platform=${BUILDPLATFORM:-linux/amd64} ghcr.io/tiiuae/fog-ros-sdk:v3.3.0-${TARGETARCH:-amd64} AS builder
+FROM --platform=${BUILDPLATFORM:-linux/amd64} ghcr.io/tiiuae/fog-ros-sdk:sha-926c935-${TARGETARCH:-amd64} AS builder
 
 # Must be defined another time after "FROM" keyword.
 ARG TARGETARCH
@@ -13,7 +13,7 @@ RUN /packaging/build_colcon_sdk.sh ${TARGETARCH:-amd64}
 
 FROM ghcr.io/tiiuae/pkcs11-closer:sha-7bec028 AS closer
 
-FROM ghcr.io/tiiuae/fog-ros-baseimage:v3.3.0
+FROM ghcr.io/tiiuae/fog-ros-baseimage:sha-926c935
 
 RUN apt-get update \
     && apt-get install -y \


### PR DESCRIPTION
Update fog-ros-baseimage from sha-c04d413 to v3.4.0
This PR is auto generated by a remote workflow.
Message from author of this PR;
**PX4-MSGS Upgraded to v7.0.0**
